### PR TITLE
Chunk splitting

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -13,7 +13,7 @@ const commonConfig = merge([
         output: {
             publicPath: '/',
             path: path.resolve(__dirname, 'dist'),
-            filename: 'bundle.js',
+            filename: '[name].[contenthash].js',
         },
         plugins: [
             new HtmlWebPackPlugin({

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -40,6 +40,7 @@ const productionConfig = merge([
     parts.loaders(),
     parts.minifyCSS(),
     parts.minifyJS(),
+    parts.splitBundles()
 ]);
 
 module.exports = mode => {

--- a/client/webpack.parts.js
+++ b/client/webpack.parts.js
@@ -1,3 +1,4 @@
+const webpack = require('webpack')
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
@@ -112,6 +113,10 @@ exports.minifyJS = () => ({
 })
 
 exports.splitBundles = () => ({
+    plugins: [
+        // Ignore all locale files of moment.js
+        new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+      ],
     optimization: {
         runtimeChunk: 'single',
         splitChunks: {

--- a/client/webpack.parts.js
+++ b/client/webpack.parts.js
@@ -108,5 +108,16 @@ exports.minifyCSS = () => ({
 exports.minifyJS = () => ({
     optimization: {
         minimizer: [new TerserPlugin({ sourceMap: true })],
+        moduleIds: 'hashed',
+        runtimeChunk: 'single',
+        splitChunks: {
+            cacheGroups: {
+              vendor: {
+                test: /[\\/]node_modules[\\/]/,
+                name: 'vendors',
+                chunks: 'all'
+              }
+            }
+        },
     }
 })

--- a/client/webpack.parts.js
+++ b/client/webpack.parts.js
@@ -108,16 +108,25 @@ exports.minifyCSS = () => ({
 exports.minifyJS = () => ({
     optimization: {
         minimizer: [new TerserPlugin({ sourceMap: true })],
-        moduleIds: 'hashed',
+    }
+})
+
+exports.splitBundles = () => ({
+    optimization: {
         runtimeChunk: 'single',
         splitChunks: {
-            cacheGroups: {
-              vendor: {
-                test: /[\\/]node_modules[\\/]/,
-                name: 'vendors',
-                chunks: 'all'
-              }
-            }
-        },
-    }
+         chunks: 'all',
+         maxInitialRequests: Infinity,
+         minSize: 0,
+         cacheGroups: {
+           vendor: {
+            test: /[\\/]node_modules[\\/]/,
+            name(module) {
+            const packageName = module.context.match(/[\\/]node_modules[\\/](.*?)([\\/]|$)/)[1];
+            return `npm.${packageName.replace('@', '')}`;
+           },
+         },
+       },
+      },
+     }
 })


### PR DESCRIPTION
We now have a bundle for our main app + one for each package included. This will allow for better client caching. I'm also ignoring `moment`s locales by default, it had a bloated bundle of >260kb originally and we're only using a subset of its exported functions. Ignoring brought this down to 53Kb almost 1/5 of the size!

https://github.com/jmblog/how-to-optimize-momentjs-with-webpack gives more details on why / how this is being done and how to use `moment` locales in future with the current optimisation in place.

Before:
<img width="496" alt="Screenshot 2019-07-26 at 16 20 38" src="https://user-images.githubusercontent.com/22455561/61962453-70f27e80-afc1-11e9-8e5b-5081141944ff.png">

After: 
<img width="636" alt="Screenshot 2019-07-26 at 16 19 16" src="https://user-images.githubusercontent.com/22455561/61962485-836cb800-afc1-11e9-8eec-27dc2d238090.png">

