### PR TITLE
Travis parallel testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,22 +2,20 @@ language: node_js
 node_js:
   - 8
   - 10
+env:
+  - TEST_SUITE=client
+  - TEST_SUITE=server
 
 matrix:
   allowed_failures:
     - node_js: 8
 install:
-  - cd server
+  - cd $TEST_SUITE
   - yarn
-  - yarn build
-  - cd ../client
-  - yarn
-  - cd ../
 
 cache: yarn
 
 script:
-  - cd server
-  - yarn lint && yarn test:cov
-  - cd ../client
+  - cd $TEST_SUITE
+  - yarn build
   - yarn lint && yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,12 @@ matrix:
   allowed_failures:
     - node_js: 8
 install:
+  # This sets the context for the whole thing
   - cd $TEST_SUITE
   - yarn
 
 cache: yarn
 
 script:
-  - cd $TEST_SUITE
   - yarn build
   - yarn lint && yarn test


### PR DESCRIPTION
So this changes the travis CI config so that it runs the ~frontend~ client and ~backend~ server testing suites in parallel, on separate machines. It's not faster now, but as we add more tests to each side, it'll start to show advantages.